### PR TITLE
fix: remove empty region default from generic extensions to restore Resource Manager auto-population (#58)

### DIFF
--- a/extensions/iam_generic/variables_iam.tf
+++ b/extensions/iam_generic/variables_iam.tf
@@ -20,7 +20,6 @@ variable "private_key_password" {
   default = ""
 }
 variable "region" {
-  default     = ""
   description = "The region where resources are deployed."
   type        = string
 }

--- a/extensions/network_generic/variables_network.tf
+++ b/extensions/network_generic/variables_network.tf
@@ -22,7 +22,6 @@ variable "private_key_password" {
   default = ""
 }
 variable "region" {
-  default     = ""
   description = "The region where resources are deployed."
   type        = string
 }


### PR DESCRIPTION
* Removed the empty default value from the `region` variable in the `iam_generic` and `network_generic` extensions.
* Restored automatic region selection in the Resource Manager UI by allowing the current region to be populated.

Signed-off-by: DongHee Lee <inurisis@naver.com>